### PR TITLE
Common UI and functions shifted to parent component.

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,24 +1,108 @@
 "use client";
 
 import { UserContext } from "@/components/providers/UserContextProvider";
-import { useContext, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import {
   Dropdown,
   DropdownTrigger,
   DropdownMenu,
   DropdownItem,
   Button,
+  Modal,
+  useDisclosure,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalContent,
 } from "@nextui-org/react";
 import UserTable from "@/components/ui/UserTable";
 import TourTable from "@/components/ui/TourTable";
+import { deleteDoc } from "@/utils/server_actions/documentOperations";
+import { IoMdWarning } from "react-icons/io";
 
 export default function Dasboard() {
+  //currently logged in user
   const { user } = useContext(UserContext);
+
+  //state variables
+  const [limit, setLimit] = useState(7);
   const [selectedCollection, setSelectedCollection] = useState("users");
+
+  /*changed to true after a user deletes a document. used to decide whether to reload
+   *tables or not
+   */
+  const [reload, setReload] = useState(false);
+
+  /*
+   * The UI for deleting Document is shared between Tours and Users collection.
+   * When user clicks on delete Icon openModal function is invoked in child table components
+   *  which accepts the document on which the action is performend.
+   * The doument is then saved in the selectedDoc state which is then used to display necessary
+   * information in the Modal and selectedDoc._id is used to delete the Doc from database
+   */
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  /*details that are retrived from child table componenets and displayed in modal while
+   *taking confirmation from the user and while deleting the doc
+   */
+  const [docDetails, setDocDetails] = useState<DocDetails>();
+
+  /**
+   * Initiates a request to delete doc from database and handles UI changes
+   * accroding to the state of request
+   * The function is memoized and only re-rendered when selectedDoc changes
+   * @returns {boolean} true if the document is deleted and false if user canceled the
+   *                    operation or an error occured
+   */
+  const handleDelete = useCallback(
+    async (collection: collection, onClose: () => void): Promise<boolean> => {
+      try {
+        setIsDeleting(true);
+        if (!docDetails) {
+          alert("Delete action invoked without selecting an item.");
+          return false;
+        }
+        const res = await deleteDoc(collection, docDetails._id);
+        if (res.status === "fail")
+          throw new Error(
+            res?.error || "Something went wrong Please try again."
+          );
+        alert(`Deleted Successfully}`);
+        return true;
+      } catch (err: any) {
+        alert(err.message);
+        return false;
+      } finally {
+        setIsDeleting(false);
+        onClose();
+      }
+    },
+    [docDetails]
+  );
+
+  //next-ui custom hook to  control the behavior of modal(confirmation dialogue before delete)
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
+  /**
+   * passed down to child table components to make the modal appear and
+   * to retrieve the object on which deletion is being performed
+   * @param {DocDetails} selectedDoc
+   */
+  const openModal = useCallback(
+    (details: DocDetails) => {
+      setDocDetails(details);
+      onOpen();
+    },
+    [onOpen]
+  );
+  //if user is not logged in, restrict the access
   if (Object.keys(user).length === 0)
     return <h1>Please log in to access this route.</h1>;
+
+  //if user is not admin restrict the access
   if (user?.role !== "admin")
     return <h1>Your are not allowed to access this route.</h1>;
+
   return (
     <div className="flex flex-col gap-y-4">
       <div className="flex items-start">
@@ -39,12 +123,50 @@ export default function Dasboard() {
         </Dropdown>
       </div>
       {selectedCollection === "users" ? (
-        <UserTable />
+        <UserTable deleteDoc={openModal} limit={limit} reload={reload} />
       ) : selectedCollection === "tours" ? (
-        <TourTable />
+        <TourTable deleteDoc={openModal} limit={limit} reload={reload} />
       ) : (
         <div></div>
       )}
+      <Modal className="z-50" isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1 text-red-500">
+                <div className="flex items-center justify-center">
+                  <IoMdWarning /> Warning
+                </div>
+              </ModalHeader>
+              <ModalBody>
+                You are about to delete a document from{" "}
+                {docDetails?.type === "tours" ? "tours" : "users"} with name{" "}
+                <b>{docDetails?.name}</b>. This action cannot be reversed.
+              </ModalBody>
+              <ModalFooter>
+                <Button color="primary" variant="ghost" onPress={onClose}>
+                  Close
+                </Button>
+                <Button
+                  color="danger"
+                  isLoading={isDeleting}
+                  onPress={async () => {
+                    if (!docDetails?.type)
+                      return alert("failed to decide collection type");
+                    const deleted = await handleDelete(
+                      docDetails?.type,
+                      onClose
+                    );
+                    if (deleted) setReload((prev) => !prev);
+                  }}
+                >
+                  Delete
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
     </div>
   );
 }

--- a/components/ui/TourTable.tsx
+++ b/components/ui/TourTable.tsx
@@ -1,12 +1,6 @@
 "use client";
 import { getDocs } from "@/utils/server_actions/documentOperations";
 import {
-  Button,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
   Pagination,
   Spinner,
   Table,
@@ -15,26 +9,26 @@ import {
   TableColumn,
   TableHeader,
   TableRow,
-  useDisclosure,
   Tooltip,
 } from "@nextui-org/react";
 import { useRouter } from "next/navigation";
-import {  useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { BiPencil, BiTrash } from "react-icons/bi";
-import { IoMdWarning } from "react-icons/io";
-export default function TourTable() {
+export default function TourTable({
+  deleteDoc,
+  limit,
+  reload,
+}: {
+  limit: number;
+  deleteDoc: (details: DocDetails) => void;
+  reload: boolean;
+}) {
   const router = useRouter();
-  const [reloadTours, setReloadTours] = useState(false);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(0);
   const [tableItems, setTableItems] = useState<TourDetailed[]>([]);
-  const [limit, setLimit] = useState(10);
   const [isLoading, setIsLoading] = useState<"loading" | "idle">("idle");
-  const [selectedTour, setSelectedTour] = useState<TourDetailed>();
-  const [isDeleting, setIsDeleting] = useState(false);
 
-  //next-ui custom hook to  control the behavior of modal(confirmation dialogue before delete)
-  const { isOpen, onOpen, onOpenChange } = useDisclosure();
   useEffect(() => {
     const fetchTours = async () => {
       setIsLoading("loading");
@@ -47,47 +41,52 @@ export default function TourTable() {
       setIsLoading("idle");
     };
     fetchTours();
-  }, [page, reloadTours, limit]);
+  }, [limit, page, reload]);
 
-  
-  const renderCell = useCallback((tour: TourDetailed, columnKey: string) => {
-    switch (columnKey) {
-      case "name":
-        return <p>{tour.name}</p>;
-      case "price":
-        return <p>{tour.price}</p>;
-      case "difficulty":
-        return <p>{tour.difficulty}</p>;
-      case "rating":
-        return <p>{tour.ratingsAverage}</p>;
-      case "guides":
-        return <p>{tour.guides.length}</p>;
-      case "actions":
-        return (
-          <div className="relative flex items-center gap-3">
-            <Tooltip content="Edit user">
-              <span
-                className="text-lg text-default-400 cursor-pointer active:opacity-50"
-                onClick={() => router.push(`/tours/edit/${tour._id}`)}
-              >
-                <BiPencil />
-              </span>
-            </Tooltip>
-            <Tooltip color="danger" content="Delete tour">
-              <span
-                className="text-lg text-danger cursor-pointer active:opacity-50"
-                onClick={() => {
-                  setSelectedTour(tour);
-                  onOpen();
-                }}
-              >
-                <BiTrash />
-              </span>
-            </Tooltip>
-          </div>
-        );
-    }
-  }, []);
+  const renderCell = useCallback(
+    (tour: TourDetailed, columnKey: string) => {
+      switch (columnKey) {
+        case "name":
+          return <p>{tour.name}</p>;
+        case "price":
+          return <p>{tour.price}</p>;
+        case "difficulty":
+          return <p>{tour.difficulty}</p>;
+        case "rating":
+          return <p>{tour.ratingsAverage}</p>;
+        case "guides":
+          return <p>{tour.guides.length}</p>;
+        case "actions":
+          return (
+            <div className="relative flex items-center gap-3">
+              <Tooltip content="Edit user">
+                <span
+                  className="text-lg text-default-400 cursor-pointer active:opacity-50"
+                  onClick={() => router.push(`/tours/edit/${tour._id}`)}
+                >
+                  <BiPencil />
+                </span>
+              </Tooltip>
+              <Tooltip color="danger" content="Delete tour">
+                <span
+                  className="text-lg text-danger cursor-pointer active:opacity-50"
+                  onClick={() => {
+                    deleteDoc({
+                      _id: tour._id,
+                      type: "tours",
+                      name: tour.name,
+                    });
+                  }}
+                >
+                  <BiTrash />
+                </span>
+              </Tooltip>
+            </div>
+          );
+      }
+    },
+    [deleteDoc, router]
+  );
   return (
     <>
       <Table
@@ -130,37 +129,6 @@ export default function TourTable() {
           )}
         </TableBody>
       </Table>
-      <Modal className="z-50" isOpen={isOpen} onOpenChange={onOpenChange}>
-        <ModalContent>
-          {(onClose) => (
-            <>
-              <ModalHeader className="flex flex-col gap-1 text-red-500">
-                <div className="flex items-center justify-center">
-                  <IoMdWarning /> Warning
-                </div>
-              </ModalHeader>
-              <ModalBody>
-                You are about to delete the tour named <b>{selectedTour?.name}</b>{" "}
-                This action cannot be reversed.
-              </ModalBody>
-              <ModalFooter>
-                <Button color="primary" variant="ghost" onPress={onClose}>
-                  Close
-                </Button>
-                <Button
-                  color="danger"
-                  isLoading={isDeleting}
-                  onPress={() => {
-                    // handleDelete(onClose);
-                  }}
-                >
-                  Delete
-                </Button>
-              </ModalFooter>
-            </>
-          )}
-        </ModalContent>
-      </Modal>
     </>
   );
 }

--- a/utils/server_actions/documentOperations.ts
+++ b/utils/server_actions/documentOperations.ts
@@ -37,7 +37,7 @@ export async function editUser(user: User): Promise<ServerActionRes> {
  * @returns {Promise<ServerActionRes>} A Promise that resolves with the server response containing the fetched documents.
  */
 export async function getDocs(
-  collection: string,
+  collection: "tours" | "users",
   filters: Filters,
   fields?: string[]
 ): Promise<ServerActionRes> {
@@ -69,11 +69,14 @@ export async function getDocs(
  * @returns {Promise<ServerActionRes>} A promise that resolves with the server response.
  *
  */
-export async function deleteUser(userId: string): Promise<ServerActionRes> {
+export async function deleteDoc(
+  collection: collection,
+  docId: string
+): Promise<ServerActionRes> {
   try {
     const headers = new Headers();
     addSessionCookieToHeader(cookies(), headers);
-    const promise = await fetch(`${env("API_URL")}/users/${userId}`, {
+    const promise = await fetch(`${env("API_URL")}/${collection}/${docId}`, {
       method: "DELETE",
       headers,
     });

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -70,3 +70,11 @@ interface Filters {
   page: number;
   limit: number;
 }
+
+interface DocDetails {
+  _id: string;
+  name: string;
+  type: collection;
+}
+
+type collection = "tours" | "users";


### PR DESCRIPTION
Modal to confirm deletion, limit option to set items per page and delete functionality has been moved from individual table to the parent to make it reusable in case more tables are added to the dashboard